### PR TITLE
Include bare feed name mentions (optionally)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ but simpler, because it relies only on the markdown.
 ``` js
 var mentions = require('ssb-mentions')
 
-var ary = mentions(markdown)
+var ary = mentions(markdown, opts)
 
 ```
+
+## options
+
+- `bareFeedNames` (boolean, default false): if true, include stub mention
+  objects for bare feed name mentions, in the format
+  `{name: "NAME", link: "@"}`. these can then have the `link` filled in with a
+  feed id, to make a "patchwork-style mention", or be removed from the mentions
+  array before publishing.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ function links (s, _onLink) {
   onLink = noop
 }
 
-module.exports = function (text) {
+module.exports = function (text, opts) {
+  var bareFeedNames = opts && opts.bareFeedNames
   var a = []
   links(text, function (link) {
     if(ref.isFeed(link.target))
@@ -37,6 +38,8 @@ module.exports = function (text) {
       a.push({link: link.target, name: link.label})
     else if(ref.isMsg(link.target))
       a.push({link: link.target, name: link.label})
+    else if(bareFeedNames && link.target && link.target[0] === '@')
+      a.push({link: link.target[0], name: link.target.substr(1)})
   })
   return a
 }

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -56,3 +56,9 @@ test('ref mentions are detected', function (t) {
 
   t.end()
 })
+
+test('bare feed name mentions can be detected', function (t) {
+  t.deepEquals(mentions('a @feed mention', {bareFeedNames: true}),
+    [{name: 'feed', link: '@'}], 'feed link')
+  t.end()
+})


### PR DESCRIPTION
This PR adds support for extracting name-only feed mentions (i.e. "patchwork-style mentions"). For `"@feedname"`, it would format the mention as `{name: "feedname", link: "@"}`. This "stub" mention is the most simple way i could think of to indicate to the application that the mention is a patchwork-style mention for a feed that needs the link part to be filled in. Because the un-filled-in stub would not be valid or useful in the database, i let this feature be enabled only when setting an appropriate `opts` argument. When using this feature the application should set the link property of the mention to a feed id according to the intent of the user, or remove the stub mention before publishing the message.

My main use case for this is in [patchfoo](https://git.scuttlebot.io/%25YAg1hicat%2B2GELjE2QJzDwlAWcx0ML%2B1sXEdsWwvdt8%3D.sha256) to make a way to mention feeds by name in the message composer, without having to manually type the `[@name](@id)` markdown. This is because I am targetting browsers without JS, so a suggest-box completion in the composer can't be done (or it could be done in a klunky way but i think this way is nicer. [pic](https://cloud.githubusercontent.com/assets/95347/23873518/b3fd67b6-0808-11e7-8067-672b72e00d5b.png)). Also, i think this could be good for building CLI applications, where e.g. a user could be prompted interactively to resolve their feed name mentions (or conflicts thereof).

I also had code that detected name-only message and blob mentions, but I'm not including that in this PR, because our existing UIs don't handle name-only mentions of those types.