### PR TITLE
Detect hashtags

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ extractor.mention = function (_, id) {
   onLink({target: id})
 }
 
+extractor.hashtag = function (_, hashtag) {
+  onLink({target: hashtag})
+}
+
 extractor.link = function (href, _, text) {
   onLink({label: text, target: href, embed: false})
 }
@@ -40,6 +44,8 @@ module.exports = function (text, opts) {
       a.push({link: link.target, name: link.label})
     else if(bareFeedNames && link.target && link.target[0] === '@')
       a.push({link: link.target[0], name: link.target.substr(1)})
+    else if(link.target && link.target[0] === '#')
+      a.push({link: link.target})
   })
   return a
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/ssb-mentions.git"
   },
   "dependencies": {
-    "ssb-marked": "^0.5.4",
+    "ssb-marked": "^0.7.0",
     "ssb-ref": "^2.3.0"
   },
   "devDependencies": {

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -62,3 +62,9 @@ test('bare feed name mentions can be detected', function (t) {
     [{name: 'feed', link: '@'}], 'feed link')
   t.end()
 })
+
+test('detect hashtags', function (t) {
+  t.deepEquals(mentions('a nice #hashtag here'),
+    [{link: '#hashtag'}], 'hashtag link')
+  t.end()
+})


### PR DESCRIPTION
Depends on https://github.com/ssbc/marked/pull/3

Also discussed in https://github.com/ssbc/ssb-mentions/commit/7dddf563b70151439cb54dd248531527f3645ffc#commitcomment-21366560
Changes since that commit:
- Use link instead of name property of mention
- Detect hashtags always, not just when an option is set
- Improve robustness