### PR TITLE
Remove html from mention names

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,29 @@ function noop(){}
 var onLink = noop
 var extractor = new marked.Renderer()
 
+// prevent html from entering into mention labels.
+// code taken from ssb-markdown
+extractor.code = function(code, lang, escaped) { return escaped ? unquote(code) : code }
+extractor.blockquote = function(quote) { return unquote(quote) }
+extractor.html = function(html) { return false }
+extractor.heading = function(text, level, raw) { return unquote(text)+' ' }
+extractor.hr = function() { return ' --- ' }
+extractor.br = function() { return ' ' }
+extractor.list = function(body, ordered) { return unquote(body) }
+extractor.listitem = function(text) { return '- '+unquote(text) }
+extractor.paragraph = function(text) { return unquote(text)+' ' }
+extractor.table = function(header, body) { return unquote(header + ' ' + body) }
+extractor.tablerow = function(content) { return unquote(content) }
+extractor.tablecell = function(content, flags) { return unquote(content) }
+extractor.strong = function(text) { return unquote(text) }
+extractor.em = function(text) { return unquote(text) }
+extractor.codespan = function(text) { return unquote(text) }
+extractor.del = function(text) { return unquote(text) }
+
+function unquote (text) {
+  return text.replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, '\'')
+}
+
 extractor.mention = function (_, id) {
   onLink({target: id})
 }

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -68,3 +68,14 @@ test('detect hashtags', function (t) {
     [{link: '#hashtag'}], 'hashtag link')
   t.end()
 })
+
+test('no html tags in link names', function (t) {
+  t.deepEquals(mentions('link: [`code` *em* **strong** ~~del~~]' +
+    '(&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256)'), [
+    {
+      link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
+      name: 'code em strong del'
+    }
+  ], 'no tags')
+  t.end()
+})


### PR DESCRIPTION
Some messages have html in the mention name. In particular, code tags and and em tags when using the format ```[`thing`](link)```.

Examples:

```
$ grep '<' ~/src/flume-ssb-examples/.flume-ssb/named.json
      "power structure <em>restructure</em> it self easily?": "%+LVp8bdXOYvX9tRGviuVrrAnhhI4QJXHQuVg+w4aVOs=.sha256",
      "<code>brought to you by %arrclock</code>": "%8EuiTg43nThFJdeqkBD7IJaSDYD8Zj5Djsy1/BEeVwY=.sha256",
      "dead<em>jessy</em>):": "@jFf8MDyDP8pI8kDXa9ZQG2TY5ALJrTNMMRzdIbepHLM=.ed25519",
      "<code>&amp;6sPsdXgHmh6VaZyxZzI8QCBl/7pXH+5eaS9jyXntayQ=.sha256</code>": "&6sPsdXgHmh6VaZyxZzI8QCBl/7pXH+5eaS9jyXntayQ=.sha256",
      "<code>viewer.scuttlebot.io</code>": "%RoXg2kQRojTbD7crHNCQCz5hUU+Uqd7ZYDKGQRY653c=.sha256",
      "<code>scuttlebot.wiki</code>": "%pQJks7JfMrsI/miWa+Eqt8gHeumH03lctfkGeE9mypU=.sha256",
      "<code>ssb-mutual-cli</code>": "%jngIleTcCV6aPp29SFpUKEvtpLpzodeLaqjgoJ43dbc=.sha256",
      "1<em>bleupulp</em>-_clouds_intro.ogg": "&A70FAlwssY77iSfqcg/NVj9LCcsoITASHwM/r+wbNU0=.sha256",
      "<code>git-ssb-web</code>": "%q5d5Du+9WkaSdjc8aJPZm+jMrqgo0tmfR+RcX5ZZ6H4=.sha256",
      "<code>git-ssb</code>": "%n92DiQh7ietE+R+X/I403LQoyf2DtR3WQfCkDKlheQU=.sha256",
      "install <code>git-ssb</code>, it&#39;s easy!": "%KJVAH7e4d8OIZ8ID4q4l8hqDnX6EiNPeABdjPEJMC64=.sha256",
      "when i propose <code>sameAs</code>": "%VvA84z3QF8D3CfkpXyaQXTvn460hDQhlgDIT+D8idoc=.sha256",
      "<code>%ssb-group</code>": "%DVDzq1Da0Zupt8YQ2Z1w182DNr7HdPTJdaQv2spacNs=.sha256",
      "<em>skill ontology</em> thing": "%RRmbWdbtt3K2lxaUTF9GlfXfyj95nyCfAzDdbxvhqLA=.sha256"
      "<em>open vs closed</em>": "%1hZPdkOSwLclhs8/ATYgkP9x+cOacIZoSG9Ef9xikPg=.sha256",
      "<em>caugh</em>": "%nrVrnO5An0BWMGK7yo1t/t7YSSdNR8KKagWSaPYPbak=.sha256",
```

This PR strips html (and the markdown) from link names for mentions.