### PR TITLE
mentions for secret blobs

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,12 @@ module.exports = function (text, opts) {
   links(text, function (link) {
     if(ref.isFeed(link.target))
       a.push({link: link.target, name: link.label && link.label.replace(/^@/, '')})
-    else if(link.target.startsWith('&'))
-      a.push({link: link.target, name: link.label})
+    else if(ref.isBlob(link.target)) {
+      var blob = ref.parseBlob(link.target)
+      var result = {link: blob.id, name: link.label}
+      if (blob.key) result.key = blob.key
+      a.push(result)
+    }
     else if(ref.isMsg(link.target))
       a.push({link: link.target, name: link.label})
     else if(bareFeedNames && link.target && link.target[0] === '@')

--- a/index.js
+++ b/index.js
@@ -67,9 +67,8 @@ module.exports = function (text, opts) {
     if(ref.isFeed(link.target))
       a.push({link: link.target, name: link.label && link.label.replace(/^@/, '')})
     else if(ref.isBlob(link.target)) {
-      var blob = ref.parseBlob(link.target)
-      var result = {link: blob.id, name: link.label}
-      if (blob.key) result.key = blob.key
+      var result = ref.parseBlob(link.target)
+      result.name = link.label
       a.push(result)
     }
     else if(ref.isMsg(link.target))

--- a/index.js
+++ b/index.js
@@ -64,21 +64,17 @@ module.exports = function (text, opts) {
   var emoji = opts && opts.emoji
   var a = []
   links(text, function (link) {
-    if(ref.isFeed(link.target))
-      a.push({link: link.target, name: link.label && link.label.replace(/^@/, '')})
-    else if(ref.isBlob(link.target)) {
-      var result = ref.parseBlob(link.target)
-      result.name = link.label
+    var result = link.target && ref.parseLink(link.target)
+    if (result) {
+      result.name = link.label && link.label.replace(/^@/, '')
       a.push(result)
-    }
-    else if(ref.isMsg(link.target))
-      a.push({link: link.target, name: link.label})
-    else if(bareFeedNames && link.target && link.target[0] === '@')
+    } else if(bareFeedNames && link.target && link.target.startsWith('@')) {
       a.push({link: link.target[0], name: link.target.substr(1)})
-    else if(link.target && link.target[0] === '#')
+    } else if(link.target && link.target.startsWith('#')) {
       a.push({link: link.target})
-    else if(emoji && link.emoji)
+    } else if(emoji && link.emoji) {
       a.push({emoji: true, name: link.label})
+    }
   })
   return a
 }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function (text, opts) {
   links(text, function (link) {
     if(ref.isFeed(link.target))
       a.push({link: link.target, name: link.label && link.label.replace(/^@/, '')})
-    else if(ref.isBlob(link.target))
+    else if(link.target.startsWith('&'))
       a.push({link: link.target, name: link.label})
     else if(ref.isMsg(link.target))
       a.push({link: link.target, name: link.label})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ssb-marked": "^0.7.0",
-    "ssb-ref": "github:ssbc/ssb-ref#secret-blobs"
+    "ssb-ref": "github:ssbc/ssb-ref#query-on-all-refs"
   },
   "devDependencies": {
     "tape": "^4.5.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ssb-marked": "^0.7.0",
-    "ssb-ref": "github:ssbc/ssb-ref#query-on-all-refs"
+    "ssb-ref": "^2.11.0"
   },
   "devDependencies": {
     "tape": "^4.5.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ssb-marked": "^0.7.0",
-    "ssb-ref": "^2.3.0"
+    "ssb-ref": "github:ssbc/ssb-ref#secret-blobs"
   },
   "devDependencies": {
     "tape": "^4.5.1"

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -18,6 +18,17 @@ test('mentions in links are detected', function (t) {
       }
     ], 'msg link')
 
+    t.deepEquals(mentions(
+      '[a secret msg](%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256?unbox=9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7=.boxs)'), [
+        {
+          link: '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256',
+          name: 'a secret msg',
+          query: {
+            unbox: '9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7=.boxs'
+          }
+        }
+      ], 'msg link with unbox')
+
   t.deepEquals(mentions(
     '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256)'), [
       {

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -26,6 +26,15 @@ test('mentions in links are detected', function (t) {
       }
     ], 'blob link')
 
+  t.deepEquals(mentions(
+    '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256?unbox=A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.boxs)'), [
+      {
+        link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
+        key: 'A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=',
+        name: 'a blob',
+      }
+    ], 'secret blob link')
+
   t.end()
 })
 

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -30,8 +30,10 @@ test('mentions in links are detected', function (t) {
     '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256?unbox=A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.boxs)'), [
       {
         link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
-        key: 'A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=',
         name: 'a blob',
+        query: {
+          unbox: 'A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.boxs'
+        }
       }
     ], 'secret blob link')
 


### PR DESCRIPTION
@dominictarr's [secret blobs proposal]() adds a query string onto the end of a blob ID containing the unbox key. These are not able to be detected by the mentions checker and so never get added to the `msg.value.content.mentions` array.

This PR fixes it by instead checking to see if the ID starts with a `&` and then assumes it is a blob. I did it this way because it was the same way @dominictarr did it ssbc/patchcore#50

I'm a little worried that we are veering of the "spec" established by `ssb-ref` here. Should we just update `ssb-ref` instead to be able to handle blob unbox in the id? 

Thoughts? 

cc @mixmix @clehner @ahdinosaur et el