### PR TITLE
don't include duplicate mentions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var marked = require('ssb-marked')
 function noop(){}
 var onLink = noop
 var extractor = new marked.Renderer()
+var deepEquals = require('deep-equals')
 
 // prevent html from entering into mention labels.
 // code taken from ssb-markdown
@@ -65,17 +66,26 @@ module.exports = function (text, opts) {
   var a = []
   links(text, function (link) {
     var result = link.target && ref.parseLink(link.target)
+    var mention = null
     if (result) {
       result.name = link.label && link.label.replace(/^@/, '')
-      a.push(result)
+      mention = result
     } else if(bareFeedNames && link.target && link.target.startsWith('@')) {
-      a.push({link: link.target[0], name: link.target.substr(1)})
+      mention = {link: link.target[0], name: link.target.substr(1)}
     } else if(link.target && link.target.startsWith('#')) {
-      a.push({link: link.target})
+      mention = {link: link.target}
     } else if(emoji && link.emoji) {
-      a.push({emoji: true, name: link.label})
+      mention = {emoji: true, name: link.label}
     }
+
+    for(var i = 0; i < a.length; i++)
+      if(deepEquals(a[i], mention)) return
+    a.push(mention)
   })
   return a
 }
+
+
+
+
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/ssb-mentions.git"
   },
   "dependencies": {
+    "deep-equals": "0.0.2",
     "ssb-marked": "^0.7.0",
     "ssb-ref": "^2.11.0"
   },

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -2,24 +2,30 @@ var test = require('tape')
 var mentions = require('../')
 
 test('mentions in links are detected', function (t) {
-  t.deepEquals(mentions(
-    '[@feed](@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519)'), [
+  function testMention(string, output, message) {
+    t.deepEquals(mentions(string), output, message)
+    t.deepEquals(mentions(string+ ' ' + string), output, message+', doubled')
+  }
+
+  testMention(
+    '[@feed](@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519)', [
       {
         link: '@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519',
         name: 'feed',
       }
     ], 'feed link')
 
-  t.deepEquals(mentions(
-    '[a msg](%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256)'), [
+
+  testMention(
+    '[a msg](%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256)', [
       {
         link: '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256',
         name: 'a msg',
       }
     ], 'msg link')
 
-    t.deepEquals(mentions(
-      '[a secret msg](%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256?unbox=9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7=.boxs)'), [
+    testMention(
+      '[a secret msg](%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256?unbox=9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7=.boxs)', [
         {
           link: '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256',
           name: 'a secret msg',
@@ -29,16 +35,16 @@ test('mentions in links are detected', function (t) {
         }
       ], 'msg link with unbox')
 
-  t.deepEquals(mentions(
-    '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256)'), [
+  testMention(
+    '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256)', [
       {
         link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
         name: 'a blob',
       }
     ], 'blob link')
 
-  t.deepEquals(mentions(
-    '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256?unbox=A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.boxs)'), [
+  testMention(
+    '[a blob](&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256?unbox=A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.boxs)', [
       {
         link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
         name: 'a blob',
@@ -52,24 +58,29 @@ test('mentions in links are detected', function (t) {
 })
 
 test('ref mentions are detected', function (t) {
-  t.deepEquals(mentions(
-    '@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519'), [
+  function testMention(string, output, message) {
+    t.deepEquals(mentions(string), output, message)
+    t.deepEquals(mentions(string+ ' ' + string), output, message+', doubled')
+  }
+
+  testMention(
+    '@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519', [
       {
         link: '@3HO6R2i60XNR3h6XCHAWCdt1k9Dwy+gaa2rVs6LzZ6Y=.ed25519',
         name: undefined
       }
     ], 'feed link')
 
-  t.deepEquals(mentions(
-    '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256'), [
+  testMention(
+    '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256', [
       {
         link: '%A2LvseOYKDXyuSGlXl3Sz0F5j2khVCN6JTf8ORD/tM8=.sha256',
         name: undefined
       }
     ], 'msg link')
 
-  t.deepEquals(mentions(
-    '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256'), [
+  testMention(
+    '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256', [
       {
         link: '&9SSTQys34p9f4zqjxvRwENjFX0JapgtesRey7+fxK14=.sha256',
         name: undefined
@@ -80,7 +91,7 @@ test('ref mentions are detected', function (t) {
 })
 
 test('bare feed name mentions can be detected', function (t) {
-  t.deepEquals(mentions('a @feed mention', {bareFeedNames: true}),
+  t.deepEqual(mentions('a @feed mention', {bareFeedNames: true}),
     [{name: 'feed', link: '@'}], 'feed link')
   t.end()
 })
@@ -109,3 +120,4 @@ test('detect emoji', function (t) {
   ], 'emoji')
   t.end()
 })
+


### PR DESCRIPTION
if you mention someone twice in the markdown, don't include that link twice. Although, if you use two different names or link text, then it is mentioned twice.

This has some flow on effects where it could cause a private message to hit max recipients limit, but not really just because it encrypts to the same recipient twice!

test coverage in included.