### PR TITLE
Fix Travis CI using old Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: node_js
-node_js:
-  - 0.6
-  - 0.8
+node_js: node


### PR DESCRIPTION
Problem: Travis was set up using ancient versions of Node that don't
work anymore, so the tests were constantly failing.

Solution: Use the latest Node.js version by default.