### PR TITLE
No nulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: node_js
-node_js:
-  - 0.6
-  - 0.8
+node_js: node

--- a/index.js
+++ b/index.js
@@ -81,7 +81,10 @@ module.exports = function (text, opts) {
 
     for(var i = 0; i < a.length; i++)
       if(isEqual(a[i], mention)) return
-    a.push(mention)
+
+    if (mention != null) {
+      a.push(mention)
+    }
   })
   return a
 }

--- a/test/mentions.js
+++ b/test/mentions.js
@@ -121,3 +121,7 @@ test('detect emoji', function (t) {
   t.end()
 })
 
+test('links don\'t return null mentions', function (t) {
+  t.deepEquals(mentions('look at http://example.com friends'), [] , 'empty array')
+  t.end()
+})


### PR DESCRIPTION
Problem: When an HTTP(S) link is present in the text, SSB-Mentions seems
to be adding `null` as a mention, which is causing bugs downstream.

Solution: Never add `null` to the mentions array and add a test to
ensure that this never happens.

Includes #16 
Should resolve https://github.com/ssbc/patchwork/issues/1248